### PR TITLE
fix: reject truncated chapter output in generation pipeline

### DIFF
--- a/src/enhancedChapterEngine.ts
+++ b/src/enhancedChapterEngine.ts
@@ -253,7 +253,7 @@ ${buildChapterGoalSection(params, enhancedOutline)}
 
       if (!qcResult.hit) break;
 
-      console.log(`⚠️ 章节 ${chapterIndex} 检测到提前完结信号，尝试重写 (${attempt + 1}/${maxRewriteAttempts})`);
+      console.log(`⚠️ 章节 ${chapterIndex} 检测到 QC 异常信号，尝试重写 (${attempt + 1}/${maxRewriteAttempts})`);
       
       params.onProgress?.(`检测到问题: ${qcResult.reasons[0]}，正在修复...`, 'repairing');
 
@@ -275,6 +275,13 @@ ${buildChapterGoalSection(params, enhancedOutline)}
 
       wasRewritten = true;
       rewriteCount++;
+    }
+
+    const finalQuickQc = quickEndingHeuristic(chapterText);
+    if (finalQuickQc.hit) {
+      const reason = finalQuickQc.reasons[0] || '章节内容疑似不完整';
+      params.onProgress?.(`QC 未通过: ${reason}`, 'reviewing');
+      throw new Error(`第 ${chapterIndex} 章 QC 未通过: ${reason}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- treat model responses with stopReason=length as generation failures
- extend quick chapter QC to detect likely truncated endings
- fail chapter generation when quick QC still fails after rewrite attempts
- apply the same final quick-QC gate in enhanced chapter generation

## Why
Truncated chapter text (ending mid-sentence) was still saved and counted as successful generation, causing false progress and misleading QC status.

## Verification
- TypeScript compile: tsc --noEmit
