### PR TITLE
feat: overhaul provider mode with mainstream presets

### DIFF
--- a/src/aiClient.ts
+++ b/src/aiClient.ts
@@ -1,7 +1,7 @@
 import { GoogleGenAI } from '@google/genai';
 import OpenAI from 'openai';
 
-export type AIProvider = 'gemini' | 'openai' | 'deepseek' | 'custom';
+export type AIProvider = string;
 
 export interface AIConfig {
   provider: AIProvider;
@@ -11,7 +11,7 @@ export interface AIConfig {
 }
 
 // Provider base URLs
-const PROVIDER_BASE_URLS: Partial<Record<AIProvider, string>> = {
+const PROVIDER_BASE_URLS: Record<string, string> = {
   openai: 'https://api.openai.com/v1',
   deepseek: 'https://api.deepseek.com/v1',
 };
@@ -183,7 +183,7 @@ export function getAIConfigFromHeaders(headers: Record<string, string | string[]
   }
   
   return {
-    provider: provider as AIProvider,
+    provider,
     model,
     apiKey,
     baseUrl,

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -1,8 +1,23 @@
 import { Hono } from 'hono';
 import type { Env } from '../worker.js';
 import { generateText, AIProvider } from '../services/aiClient';
+import { getProviderPresets } from '../services/providerCatalog.js';
 
 export const configRoutes = new Hono<{ Bindings: Env }>();
+
+// Public provider presets for client-side custom provider settings
+configRoutes.get('/provider-presets', async (c) => {
+  return c.json({
+    success: true,
+    providers: getProviderPresets().map((item) => ({
+      id: item.id,
+      label: item.label,
+      protocol: item.protocol,
+      defaultBaseUrl: item.defaultBaseUrl || '',
+      isCustom: Boolean(item.isCustom),
+    })),
+  });
+});
 
 // Test AI connection (config passed in body, not stored on server)
 configRoutes.post('/test', async (c) => {
@@ -51,4 +66,3 @@ async function testAIConnection(config: {
     return { success: false, message: `连接失败: ${(error as Error).message}` };
   }
 }
-

--- a/src/services/providerCatalog.ts
+++ b/src/services/providerCatalog.ts
@@ -1,0 +1,85 @@
+export type ProviderProtocol = 'openai' | 'gemini' | 'anthropic';
+
+export type ProviderPreset = {
+  id: string;
+  label: string;
+  protocol: ProviderProtocol;
+  defaultBaseUrl?: string;
+  aliases?: string[];
+  isCustom?: boolean;
+};
+
+const PRESETS: ProviderPreset[] = [
+  { id: 'openai', label: 'OpenAI', protocol: 'openai', defaultBaseUrl: 'https://api.openai.com/v1' },
+  { id: 'anthropic', label: 'Anthropic', protocol: 'anthropic', defaultBaseUrl: 'https://api.anthropic.com' },
+  { id: 'gemini', label: 'Google Gemini', protocol: 'gemini', defaultBaseUrl: 'https://generativelanguage.googleapis.com' },
+  { id: 'deepseek', label: 'DeepSeek', protocol: 'openai', defaultBaseUrl: 'https://api.deepseek.com/v1' },
+  { id: 'zai', label: 'Zhipu GLM (zAI)', protocol: 'openai', defaultBaseUrl: 'https://open.bigmodel.cn/api/paas/v4', aliases: ['zhipu', 'glm', 'bigmodel', 'z-ai'] },
+  { id: 'moonshot', label: 'Moonshot (Kimi)', protocol: 'openai', defaultBaseUrl: 'https://api.moonshot.cn/v1', aliases: ['kimi'] },
+  { id: 'qwen', label: 'Qwen / DashScope', protocol: 'openai', defaultBaseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1', aliases: ['dashscope', 'aliyun', 'bailian'] },
+  { id: 'openrouter', label: 'OpenRouter', protocol: 'openai', defaultBaseUrl: 'https://openrouter.ai/api/v1' },
+  { id: 'groq', label: 'Groq', protocol: 'openai', defaultBaseUrl: 'https://api.groq.com/openai/v1' },
+  { id: 'xai', label: 'xAI', protocol: 'openai', defaultBaseUrl: 'https://api.x.ai/v1', aliases: ['grok'] },
+  { id: 'together', label: 'Together AI', protocol: 'openai', defaultBaseUrl: 'https://api.together.xyz/v1' },
+  { id: 'siliconflow', label: 'SiliconFlow', protocol: 'openai', defaultBaseUrl: 'https://api.siliconflow.cn/v1' },
+  { id: 'mistral', label: 'Mistral', protocol: 'openai', defaultBaseUrl: 'https://api.mistral.ai/v1' },
+  { id: 'fireworks', label: 'Fireworks AI', protocol: 'openai', defaultBaseUrl: 'https://api.fireworks.ai/inference/v1' },
+  { id: 'custom', label: 'Custom (OpenAI-compatible)', protocol: 'openai', isCustom: true },
+];
+
+const BASE_URL_HINTS: Array<{ pattern: RegExp; providerId: string }> = [
+  { pattern: /open\.bigmodel\.cn|api\.z\.ai/i, providerId: 'zai' },
+  { pattern: /api\.deepseek\.com/i, providerId: 'deepseek' },
+  { pattern: /generativelanguage\.googleapis\.com/i, providerId: 'gemini' },
+  { pattern: /api\.anthropic\.com/i, providerId: 'anthropic' },
+  { pattern: /openrouter\.ai/i, providerId: 'openrouter' },
+  { pattern: /api\.moonshot\.cn/i, providerId: 'moonshot' },
+  { pattern: /dashscope\.aliyuncs\.com/i, providerId: 'qwen' },
+  { pattern: /api\.groq\.com/i, providerId: 'groq' },
+  { pattern: /api\.x\.ai/i, providerId: 'xai' },
+  { pattern: /api\.together\.xyz/i, providerId: 'together' },
+  { pattern: /api\.siliconflow\.cn/i, providerId: 'siliconflow' },
+  { pattern: /api\.mistral\.ai/i, providerId: 'mistral' },
+  { pattern: /api\.fireworks\.ai/i, providerId: 'fireworks' },
+];
+
+const PRESET_BY_ID = new Map<string, ProviderPreset>();
+const ALIAS_TO_ID = new Map<string, string>();
+
+for (const preset of PRESETS) {
+  PRESET_BY_ID.set(preset.id, preset);
+  ALIAS_TO_ID.set(preset.id, preset.id);
+  for (const alias of preset.aliases || []) {
+    ALIAS_TO_ID.set(alias, preset.id);
+  }
+}
+
+function sanitizeProvider(raw: string): string {
+  return raw.trim().toLowerCase().replace(/[\s_]+/g, '-');
+}
+
+export function normalizeProviderId(provider?: string): string {
+  const raw = (provider || '').trim();
+  if (!raw) return 'custom';
+  const candidate = sanitizeProvider(raw);
+  return ALIAS_TO_ID.get(candidate) || candidate;
+}
+
+export function detectProviderByBaseUrl(baseUrl?: string): string | null {
+  if (!baseUrl) return null;
+  for (const hint of BASE_URL_HINTS) {
+    if (hint.pattern.test(baseUrl)) {
+      return hint.providerId;
+    }
+  }
+  return null;
+}
+
+export function getProviderPreset(provider?: string): ProviderPreset | null {
+  const normalized = normalizeProviderId(provider);
+  return PRESET_BY_ID.get(normalized) || null;
+}
+
+export function getProviderPresets(): ProviderPreset[] {
+  return PRESETS.map((preset) => ({ ...preset }));
+}

--- a/web/src/hooks/useAIConfig.ts
+++ b/web/src/hooks/useAIConfig.ts
@@ -3,7 +3,8 @@ export {
   useAIConfig, 
   AIConfigProvider, 
   getAIConfigHeaders, 
-  PROVIDER_MODELS 
+  PROVIDER_MODELS,
+  BUILTIN_PROVIDER_PRESETS
 } from '@/contexts/AIConfigContext';
 
 export type { AIConfig, AIProvider } from '@/contexts/AIConfigContext';

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1029,3 +1029,28 @@ export async function fetchRemoteModels(
   return data.models;
 }
 
+export type ProviderPreset = {
+  id: string;
+  label: string;
+  protocol: 'openai' | 'gemini' | 'anthropic';
+  defaultBaseUrl?: string;
+  isCustom?: boolean;
+};
+
+export async function fetchProviderPresets(): Promise<ProviderPreset[]> {
+  const res = await fetch(`${API_BASE}/admin/provider-presets`, {
+    headers: defaultHeaders(),
+  });
+  const data = await res.json();
+  if (!data.success) throw new Error(data.error);
+  return data.providers || [];
+}
+
+export async function fetchPublicProviderPresets(): Promise<ProviderPreset[]> {
+  const res = await fetch(`${API_BASE}/config/provider-presets`, {
+    headers: defaultHeaders(),
+  });
+  const data = await res.json();
+  if (!data.success) throw new Error(data.error || data.message || '加载 provider 列表失败');
+  return data.providers || [];
+}


### PR DESCRIPTION
## Summary
- add a backend provider catalog with normalized IDs, aliases, protocol metadata, and default base URLs
- expand admin model registry and remote model fetch to support mainstream providers and dynamic provider presets
- add a public provider preset API endpoint for non-admin custom-provider users
- refactor frontend AI config to dynamic providers, per-provider saved settings, alias normalization, and model suggestions
- upgrade admin provider UI to consume dynamic preset list instead of hardcoded providers

## Validation
- pnpm -s typecheck
- cd web && pnpm -s build
