### PR TITLE
fix: show chapter retry reasons and support title+body outputs

### DIFF
--- a/src/utils/chapterText.ts
+++ b/src/utils/chapterText.ts
@@ -42,19 +42,67 @@ export function looksLikeJsonChapterPayload(text: string): boolean {
   return /"content"\s*:/.test(cleaned) && /"title"\s*:/.test(cleaned);
 }
 
+function normalizeTitle(title: string, chapterIndex: number): string {
+  const cleaned = title.replace(/^#+\s*/, '').trim();
+  if (!cleaned) return `第${chapterIndex}章`;
+  if (/^第[一二三四五六七八九十百千万零两\d]+[章节回]/.test(cleaned)) {
+    return cleaned;
+  }
+  return `第${chapterIndex}章 ${cleaned}`;
+}
+
+function extractPlainTextTitleAndBody(raw: string, chapterIndex: number): { title: string; content: string } | null {
+  const normalized = raw.replace(/\r\n/g, '\n').trim();
+  if (!normalized) return null;
+
+  const lines = normalized.split('\n');
+  const firstContentLineIndex = lines.findIndex((line) => line.trim().length > 0);
+  if (firstContentLineIndex < 0) return null;
+
+  const candidateTitleIndex = (() => {
+    for (let i = firstContentLineIndex; i < Math.min(lines.length, firstContentLineIndex + 4); i++) {
+      const line = lines[i].replace(/^#+\s*/, '').trim();
+      if (!line) continue;
+      if (/^第[一二三四五六七八九十百千万零两\d]+[章节回]/.test(line)) {
+        return i;
+      }
+      if (/^(标题|题目)\s*[:：]/.test(line)) {
+        return i;
+      }
+    }
+    return -1;
+  })();
+
+  if (candidateTitleIndex < 0) return null;
+
+  const rawTitle = lines[candidateTitleIndex]
+    .replace(/^#+\s*/, '')
+    .replace(/^(标题|题目)\s*[:：]\s*/, '')
+    .trim();
+  const title = normalizeTitle(rawTitle, chapterIndex);
+
+  const body = lines
+    .slice(candidateTitleIndex + 1)
+    .join('\n')
+    .trim();
+
+  return { title, content: body };
+}
+
 export function normalizeGeneratedChapterText(rawResponse: string, chapterIndex: number): string {
   const parsed = extractJsonObject(rawResponse);
   if (parsed && typeof parsed.content === 'string') {
-    const safeTitle = typeof parsed.title === 'string' && parsed.title.trim().length > 0
-      ? parsed.title.trim()
-      : `第${chapterIndex}章`;
-    const finalTitle = safeTitle.startsWith('第') ? safeTitle : `第${chapterIndex}章 ${safeTitle}`;
+    const finalTitle = normalizeTitle(
+      typeof parsed.title === 'string' ? parsed.title : '',
+      chapterIndex
+    );
     return `${finalTitle}\n\n${parsed.content.trim()}`;
   }
 
   const cleaned = stripCodeFence(rawResponse);
-  if (looksLikeJsonChapterPayload(cleaned)) {
-    throw new Error(`AI 返回了无效的 JSON 章节结构（第 ${chapterIndex} 章）`);
+  const plain = extractPlainTextTitleAndBody(cleaned, chapterIndex);
+  if (plain) {
+    return `${plain.title}\n\n${plain.content}`.trim();
   }
 
   return cleaned;


### PR DESCRIPTION
## Summary\n- show chapter retry attempt and failure reason in real-time progress events\n- persist retry failure reason into task current_message so polling/SSE can display actual blockers\n- remove strict JSON-only chapter dependency; support plain text chapter output with title + body\n- add chapter format QC (title + body) and trigger QC rewrite when structure is invalid\n- update rewrite instructions to enforce title+body output (no JSON/code blocks)\n\n## Validation\n- pnpm -s typecheck\n- cd web && pnpm -s build\n