### PR TITLE
perf: reduce batch chapter latency by throttling summary updates

### DIFF
--- a/migrations/0015_add_summary_update_feature.sql
+++ b/migrations/0015_add_summary_update_feature.sql
@@ -1,0 +1,20 @@
+-- Add dedicated feature key for rolling summary model routing
+INSERT OR IGNORE INTO credit_features (
+  feature_key,
+  name,
+  description,
+  base_cost,
+  model_multiplier_enabled,
+  is_vip_only,
+  is_active,
+  category
+) VALUES (
+  'generate_summary_update',
+  '更新剧情摘要',
+  '在章节生成后更新滚动剧情摘要与未解伏笔',
+  2,
+  1,
+  0,
+  1,
+  'basic'
+);

--- a/src/generateChapter.ts
+++ b/src/generateChapter.ts
@@ -21,6 +21,8 @@ const UpdateSchema = z.object({
 export type WriteChapterParams = {
   /** AI 配置 */
   aiConfig: AIConfig;
+  /** 摘要更新专用 AI 配置（可选，不传则复用 aiConfig） */
+  summaryAiConfig?: AIConfig;
   /** Story Bible 内容 */
   bible: string;
   /** 滚动剧情摘要 */
@@ -206,7 +208,7 @@ ${characters ? getCharacterContext(characters, chapterIndex) : ''}
  */
 export async function writeOneChapter(params: WriteChapterParams): Promise<WriteChapterResult> {
   const startedAt = Date.now();
-  const { aiConfig, chapterIndex, totalChapters, maxRewriteAttempts = 2, skipSummaryUpdate = false, chapterTitle } = params;
+  const { aiConfig, summaryAiConfig, chapterIndex, totalChapters, maxRewriteAttempts = 2, skipSummaryUpdate = false, chapterTitle } = params;
   const isFinal = chapterIndex === totalChapters;
 
   const system = buildSystemPrompt(isFinal, chapterIndex, chapterTitle);
@@ -278,7 +280,7 @@ export async function writeOneChapter(params: WriteChapterParams): Promise<Write
 
     // 生成更新后的摘要和伏笔
     const summaryResult = await generateSummaryUpdate(
-      aiConfig,
+      summaryAiConfig || aiConfig,
       params.bible,
       params.rollingSummary,
       params.openLoops,


### PR DESCRIPTION
## 背景
批量生成时每章都串行做一次摘要更新，导致单章耗时明显增加，尤其在模型响应慢时更明显。

## 变更
- 在 Worker 队列链路中引入摘要更新策略（以下任一满足才更新）：
  - 批次最后一章
  - 卷末章节
  - 每 N 章命中一次（默认 5，可通过 `SUMMARY_UPDATE_INTERVAL` 环境变量覆盖）
- 将 `skipSummaryUpdate` 传给 `writeOneChapter`，避免每章都触发摘要模型调用
- 增加性能日志，记录每章正文/摘要/总耗时，便于线上定位慢点
- 摘要更新降级为轻量策略：
  - 输出目标从 800~1500 字调整为 350~700 字
  - Bible 截断从 2000 降到 1200 字
  - 摘要调用 `maxTokens` 限制为 1000
  - 摘要调用重试从默认 5 次降为 2 次（失败直接 fallback）
- 摘要解析失败 fallback 时保留旧 `openLoops`，避免被清空

## 预期收益
- 批量生成总体耗时显著下降（默认策略下仅约 20% 章节触发摘要更新）
- 遇到摘要模型抖动时不再长时间阻塞章节主流程
- 日志可直接分辨慢在正文生成还是慢在摘要更新

## 验证
- `pnpm typecheck` 仍会失败，但失败点是仓库既有的 `src/server.ts` 类型问题，与本 PR 改动无关
