### PR TITLE
fix: normalize gemini base url to avoid 404

### DIFF
--- a/src/services/aiClient.ts
+++ b/src/services/aiClient.ts
@@ -1,5 +1,5 @@
 import { completeSimple, Model as PiAiModel, streamSimple, SimpleStreamOptions } from '@mariozechner/pi-ai';
-import { detectProviderByBaseUrl, getProviderPreset, normalizeProviderId } from './providerCatalog.js';
+import { detectProviderByBaseUrl, getProviderPreset, normalizeGeminiBaseUrl, normalizeProviderId } from './providerCatalog.js';
 
 export type AIProvider = string;
 
@@ -26,6 +26,7 @@ function toPiAiModel(config: AIConfig): PiAiModel<any> {
   if (preset?.protocol === 'gemini' || effectiveProvider === 'gemini') {
     api = 'google-generative-ai';
     provider = 'google';
+    baseUrl = normalizeGeminiBaseUrl(baseUrl);
   } else if (preset?.protocol === 'anthropic' || effectiveProvider === 'anthropic') {
     api = 'anthropic';
     provider = 'anthropic';

--- a/src/services/providerCatalog.ts
+++ b/src/services/providerCatalog.ts
@@ -12,7 +12,7 @@ export type ProviderPreset = {
 const PRESETS: ProviderPreset[] = [
   { id: 'openai', label: 'OpenAI', protocol: 'openai', defaultBaseUrl: 'https://api.openai.com/v1' },
   { id: 'anthropic', label: 'Anthropic', protocol: 'anthropic', defaultBaseUrl: 'https://api.anthropic.com' },
-  { id: 'gemini', label: 'Google Gemini', protocol: 'gemini', defaultBaseUrl: 'https://generativelanguage.googleapis.com' },
+  { id: 'gemini', label: 'Google Gemini', protocol: 'gemini', defaultBaseUrl: 'https://generativelanguage.googleapis.com/v1beta' },
   { id: 'deepseek', label: 'DeepSeek', protocol: 'openai', defaultBaseUrl: 'https://api.deepseek.com/v1' },
   { id: 'zai', label: 'Zhipu GLM (zAI)', protocol: 'openai', defaultBaseUrl: 'https://open.bigmodel.cn/api/paas/v4', aliases: ['zhipu', 'glm', 'bigmodel', 'z-ai'] },
   { id: 'moonshot', label: 'Moonshot (Kimi)', protocol: 'openai', defaultBaseUrl: 'https://api.moonshot.cn/v1', aliases: ['kimi'] },
@@ -82,4 +82,26 @@ export function getProviderPreset(provider?: string): ProviderPreset | null {
 
 export function getProviderPresets(): ProviderPreset[] {
   return PRESETS.map((preset) => ({ ...preset }));
+}
+
+/**
+ * Normalize Gemini base URL to API root with version path.
+ * Accepts host-only/base paths and strips accidental /models suffix.
+ */
+export function normalizeGeminiBaseUrl(baseUrl?: string): string | undefined {
+  const raw = String(baseUrl || '').trim();
+  if (!raw) return undefined;
+
+  let normalized = raw.replace(/\/+$/, '');
+  normalized = normalized.replace(/\/models(?:\/.*)?$/i, '');
+
+  if (!/generativelanguage\.googleapis\.com/i.test(normalized)) {
+    return normalized;
+  }
+
+  if (/\/v\d+(?:beta|alpha)?$/i.test(normalized)) {
+    return normalized;
+  }
+
+  return `${normalized}/v1beta`;
 }


### PR DESCRIPTION
## Problem
Gemini models configured with base URL https://generativelanguage.googleapis.com were failing with 404 during generation.

## Root Cause
pi-ai's Google provider treats any provided baseUrl as already versioned and disables API version appending. Our default/persisted Gemini URL had no /v1beta, so requests hit unversioned paths and returned 404.

## Fix
- Normalize Gemini base URL to versioned root (/v1beta)
- Update Gemini provider preset default base URL
- Normalize admin model create/update and fetch-models flow for Gemini

## Validation
- pnpm typecheck
- pnpm build:web
