### PR TITLE
fix: force next-chapter summary retry after summary failure

### DIFF
--- a/src/enhancedChapterEngine.ts
+++ b/src/enhancedChapterEngine.ts
@@ -677,7 +677,7 @@ ${chapterText}
 请按“越近越详细、越远越压缩”的原则输出更新后的 JSON。
 `.trim();
 
-  const raw = await generateTextWithRetry(aiConfig, { system, prompt, temperature: 0.2, maxTokens: 1800 }, 2);
+  const raw = await generateTextWithRetry(aiConfig, { system, prompt, temperature: 0.2, maxTokens: 1800 }, 3);
   return parseSummaryUpdateResponse(raw, previousSummary, previousOpenLoops);
 }
 


### PR DESCRIPTION
## Problem
After a summary update failure:
1. user did not see explicit retry behavior,
2. subsequent chapters in the same task might skip summary updates due to interval gating.

## Fix
- Add pending-summary retry detection from `summary_memories`:
  - if previous chapter had `summary_updated=0` and reason != deferred,
  - force summary update on current chapter (`retry_pending`).
- Add explicit summary update fallback sequence in chapter generation:
  - try summary model first,
  - fallback to primary chapter model if different.
- Increase summary generation retry depth from 2 to 3.
- Improve perf logs to distinguish deferred vs failed-summary retry.

## Validation
- pnpm typecheck
- pnpm build:web
