### PR TITLE
feat: 支持配置每章最少字数

### DIFF
--- a/migrations/0018_add_min_chapter_words.sql
+++ b/migrations/0018_add_min_chapter_words.sql
@@ -1,0 +1,2 @@
+-- Per-project minimum chapter word count
+ALTER TABLE states ADD COLUMN min_chapter_words INTEGER DEFAULT 2500;

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS states (
   project_id TEXT PRIMARY KEY REFERENCES projects(id) ON DELETE CASCADE,
   book_title TEXT DEFAULT '',
   total_chapters INTEGER DEFAULT 100,
+  min_chapter_words INTEGER DEFAULT 2500,
   next_chapter_index INTEGER DEFAULT 1,
   rolling_summary TEXT DEFAULT '',
   open_loops TEXT DEFAULT '[]',

--- a/src/generateChapter.ts
+++ b/src/generateChapter.ts
@@ -7,6 +7,22 @@ import { quickEndingHeuristic, quickChapterFormatHeuristic, buildRewriteInstruct
 import { normalizeGeneratedChapterText } from './utils/chapterText.js';
 import { normalizeRollingSummary, parseSummaryUpdateResponse } from './utils/rollingSummary.js';
 
+const DEFAULT_MIN_CHAPTER_WORDS = 2500;
+const MIN_CHAPTER_WORDS_LIMIT = 500;
+const MAX_CHAPTER_WORDS_LIMIT = 20000;
+
+function normalizeMinChapterWords(value: number | undefined): number {
+  const parsed = Number.parseInt(String(value ?? DEFAULT_MIN_CHAPTER_WORDS), 10);
+  if (!Number.isInteger(parsed)) return DEFAULT_MIN_CHAPTER_WORDS;
+  if (parsed < MIN_CHAPTER_WORDS_LIMIT) return MIN_CHAPTER_WORDS_LIMIT;
+  if (parsed > MAX_CHAPTER_WORDS_LIMIT) return MAX_CHAPTER_WORDS_LIMIT;
+  return parsed;
+}
+
+function buildRecommendedMaxChapterWords(minChapterWords: number): number {
+  return Math.max(minChapterWords + 1000, Math.round(minChapterWords * 1.5));
+}
+
 /**
  * 章节生成参数
  */
@@ -27,6 +43,8 @@ export type WriteChapterParams = {
   chapterIndex: number;
   /** 计划总章数 */
   totalChapters: number;
+  /** 每章最少字数（正文，不含标题） */
+  minChapterWords?: number;
   /** 本章写作目标提示 (可选) */
   chapterGoalHint?: string;
   /** 本章标题 (来自大纲) */
@@ -71,7 +89,13 @@ export type WriteChapterResult = {
 /**
  * 构建 System Prompt
  */
-function buildSystemPrompt(isFinal: boolean, chapterIndex: number, chapterTitle?: string): string {
+function buildSystemPrompt(
+  isFinal: boolean,
+  chapterIndex: number,
+  minChapterWords: number,
+  chapterTitle?: string
+): string {
+  const recommendedMaxWords = buildRecommendedMaxChapterWords(minChapterWords);
   const titleText = chapterTitle 
     ? `第${chapterIndex}章 ${chapterTitle}` 
     : `第${chapterIndex}章 [你需要起一个创意标题]`;
@@ -121,7 +145,7 @@ function buildSystemPrompt(isFinal: boolean, chapterIndex: number, chapterTitle?
 ═══════ 硬性规则 ═══════
 - 只有当 is_final_chapter=true 才允许收束主线
 - 若 is_final_chapter=false：严禁出现任何"完结/终章/尾声/后记/感谢读者/全书完"等收尾表达
-- 每章字数 2500~3500 汉字
+- 每章正文字数不少于 ${minChapterWords} 字，建议控制在 ${minChapterWords}~${recommendedMaxWords} 字
 - 禁止说教式总结（如"他知道这只是开始"/"从此走上了xxx之路"）
 - 禁止上帝视角旁白（如"命运的齿轮开始转动"/"历史的车轮滚滚向前"）
 - 结尾不要用总结句，直接用钩子场景收尾
@@ -147,6 +171,7 @@ function buildUserPrompt(params: Omit<WriteChapterParams, 'aiConfig'>): string {
     lastChapters,
     chapterIndex,
     totalChapters,
+    minChapterWords,
     chapterGoalHint,
     characters,
     characterStates,
@@ -191,6 +216,7 @@ ${characters ? getCharacterContext(characters, chapterIndex) : ''}
 5. 如果本章有战斗/冲突，必须有具体的招式/策略描写，不能概述
 6. 章节结尾的最后一段必须是钩子场景，不能是总结或感悟
 7. 展开具体场景而非概述，让读者"看到"而非"被告知"
+8. 本章正文字数必须至少 ${normalizeMinChapterWords(minChapterWords)} 字
 
 请写出本章内容：
 `.trim();
@@ -208,10 +234,20 @@ function isSameAiConfig(a: AIConfig, b: AIConfig): boolean {
  */
 export async function writeOneChapter(params: WriteChapterParams): Promise<WriteChapterResult> {
   const startedAt = Date.now();
-  const { aiConfig, summaryAiConfig, chapterIndex, totalChapters, maxRewriteAttempts = 2, skipSummaryUpdate = false, chapterTitle } = params;
+  const {
+    aiConfig,
+    summaryAiConfig,
+    chapterIndex,
+    totalChapters,
+    minChapterWords,
+    maxRewriteAttempts = 2,
+    skipSummaryUpdate = false,
+    chapterTitle,
+  } = params;
   const isFinal = chapterIndex === totalChapters;
+  const normalizedMinChapterWords = normalizeMinChapterWords(minChapterWords);
 
-  const system = buildSystemPrompt(isFinal, chapterIndex, chapterTitle);
+  const system = buildSystemPrompt(isFinal, chapterIndex, normalizedMinChapterWords, chapterTitle);
   const prompt = buildUserPrompt(params);
   const generationStartedAt = Date.now();
 
@@ -227,7 +263,7 @@ export async function writeOneChapter(params: WriteChapterParams): Promise<Write
   // QC 检测：结构（标题+正文）+ 非最终章提前完结检测
   for (let attempt = 0; attempt < maxRewriteAttempts; attempt++) {
     params.onProgress?.(`正在进行 QC 检测 (${attempt + 1}/${maxRewriteAttempts})...`, 'reviewing');
-    const formatQc = quickChapterFormatHeuristic(chapterText);
+    const formatQc = quickChapterFormatHeuristic(chapterText, { minBodyChars: normalizedMinChapterWords });
     const endingQc = isFinal ? { hit: false, reasons: [] as string[] } : quickEndingHeuristic(chapterText);
     const reasons = [...formatQc.reasons, ...endingQc.reasons];
 
@@ -246,6 +282,7 @@ export async function writeOneChapter(params: WriteChapterParams): Promise<Write
       totalChapters,
       reasons,
       isFinalChapter: isFinal,
+      minChapterWords: normalizedMinChapterWords,
     });
 
     const rewritePrompt = `${prompt}\n\n${rewriteInstruction}`;
@@ -256,7 +293,7 @@ export async function writeOneChapter(params: WriteChapterParams): Promise<Write
   }
 
   // 最终检查
-  const finalFormatQc = quickChapterFormatHeuristic(chapterText);
+  const finalFormatQc = quickChapterFormatHeuristic(chapterText, { minBodyChars: normalizedMinChapterWords });
   const finalEndingQc = isFinal ? { hit: false, reasons: [] as string[] } : quickEndingHeuristic(chapterText);
   const finalReasons = [...finalFormatQc.reasons, ...finalEndingQc.reasons];
   if (finalReasons.length > 0) {

--- a/src/generateOutline.ts
+++ b/src/generateOutline.ts
@@ -58,10 +58,11 @@ export async function generateMasterOutline(
     bible: string;
     targetChapters: number;
     targetWordCount: number;
+    minChapterWords?: number;
     characters?: any; // 可选：CharacterRelationGraph，先建人物再写大纲时传入
   }
 ): Promise<{ volumes: Omit<VolumeOutline, 'chapters'>[]; mainGoal: string; milestones: string[] }> {
-  const { bible, targetChapters, targetWordCount, characters } = args;
+  const { bible, targetChapters, targetWordCount, minChapterWords = 2500, characters } = args;
 
   // 估算分卷数 (通常每 50-100 章一卷)
   const volumeCount = Math.ceil(targetChapters / 80);
@@ -76,7 +77,8 @@ export async function generateMasterOutline(
 4. 悬念管理：每卷结尾必须留大悬念，牵引读者进入下一卷
 5. 三幕结构：每卷遵循「铺垫(25%) → 发展(50%) → 高潮收尾(25%)」
 6. 禁止水卷：每卷都要有明确的核心矛盾和高潮，不能有"过渡卷"
-${characters ? '7. 人物驱动：大纲必须围绕人物关系冲突展开，每卷的核心冲突应与人物关系变化绑定' : ''}
+7. 篇幅规划：章节推进要匹配字数预算，默认每章不少于 ${minChapterWords} 字
+${characters ? '8. 人物驱动：大纲必须围绕人物关系冲突展开，每卷的核心冲突应与人物关系变化绑定' : ''}
 
 输出严格的 JSON 格式，不要有其他文字。
 
@@ -132,6 +134,7 @@ ${bible}
 【目标规模】
 - 总章数: ${targetChapters} 章
 - 总字数: ${targetWordCount} 万字
+- 每章最低字数: ${minChapterWords} 字
 - 预计分卷数: ${volumeCount} 卷
 ${charactersSummary}
 
@@ -158,9 +161,10 @@ export async function generateVolumeChapters(
     masterOutline: { mainGoal: string; milestones: string[] };
     volume: Omit<VolumeOutline, 'chapters'>;
     previousVolumeSummary?: string;
+    minChapterWords?: number;
   }
 ): Promise<ChapterOutline[]> {
-  const { bible, masterOutline, volume, previousVolumeSummary } = args;
+  const { bible, masterOutline, volume, previousVolumeSummary, minChapterWords = 2500 } = args;
 
   const chapterCount = volume.endChapter - volume.startChapter + 1;
 
@@ -174,6 +178,7 @@ export async function generateVolumeChapters(
 4. 冲突升级：核心冲突要逐步升级，不能一下子解决
 5. 人物登场：新角色要安排合理的登场方式和动机
 6. 禁止水章：每章都要推动剧情，不能有纯日常的章节
+7. 篇幅意识：章节设计要支撑单章不少于 ${minChapterWords} 字，避免目标过散导致注水或空章
 
 输出严格的 JSON 数组格式，不要有其他文字。
 
@@ -198,6 +203,7 @@ ${bible.slice(0, 2000)}...
 - 本卷目标: ${volume.goal}
 - 本卷冲突: ${volume.conflict}
 - 本卷高潮: ${volume.climax}
+- 每章最低字数: ${minChapterWords} 字
 
 ${previousVolumeSummary ? `【上卷结尾摘要】\n${previousVolumeSummary}` : '【这是第一卷】'}
 

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -11,6 +11,8 @@ export type BookState = {
   bookTitle: string;
   /** 计划总章数 */
   totalChapters: number;
+  /** 每章最少字数（正文，不含标题） */
+  minChapterWords?: number;
   /** 下一章索引 (从 1 开始) */
   nextChapterIndex: number;
   /** 滚动剧情摘要 (800~1500 字) */
@@ -44,6 +46,7 @@ export async function ensureBook(
     const init: BookState = {
       bookTitle: defaults?.bookTitle ?? path.basename(projectDir),
       totalChapters: defaults?.totalChapters ?? 80,
+      minChapterWords: defaults?.minChapterWords ?? 2500,
       nextChapterIndex: defaults?.nextChapterIndex ?? 1,
       rollingSummary: defaults?.rollingSummary ?? '',
       openLoops: defaults?.openLoops ?? [],

--- a/src/runOneBook.ts
+++ b/src/runOneBook.ts
@@ -106,6 +106,7 @@ export async function runOneBook(options: RunOptions): Promise<void> {
         lastChapters,
         chapterIndex,
         totalChapters: state.totalChapters,
+        minChapterWords: state.minChapterWords,
         chapterGoalHint,
       });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -383,6 +383,7 @@ app.post('/api/projects/:name/generate', async (req: Request, res: Response) => 
         lastChapters,
         chapterIndex,
         totalChapters: state.totalChapters,
+        minChapterWords: state.minChapterWords,
         chapterGoalHint,
 
         skipSummaryUpdate: !shouldUpdateSummary,

--- a/web/src/components/WebMCPProvider.tsx
+++ b/web/src/components/WebMCPProvider.tsx
@@ -251,6 +251,7 @@ export function WebMCPProvider() {
             name,
             targetChapters,
             targetWordCount,
+            undefined,
             customPrompt,
             aiHeaders,
           );
@@ -275,7 +276,7 @@ export function WebMCPProvider() {
           const input = asObject(rawInput);
           const name = requireString(input, 'name');
           const chaptersToGenerate = requirePositiveInteger(input, 'chaptersToGenerate');
-          const generated = await generateChapters(name, chaptersToGenerate, aiHeaders);
+          const generated = await generateChapters(name, chaptersToGenerate, undefined, aiHeaders);
           return { generated };
         },
       }),

--- a/web/src/components/views/GenerateView.tsx
+++ b/web/src/components/views/GenerateView.tsx
@@ -34,9 +34,11 @@ interface GenerateViewProps {
   // Outline generation
   outlineChapters: string;
   outlineWordCount: string;
+  outlineMinChapterWords: string;
   outlineCustomPrompt: string;
   onOutlineChaptersChange: (value: string) => void;
   onOutlineWordCountChange: (value: string) => void;
+  onOutlineMinChapterWordsChange: (value: string) => void;
   onOutlineCustomPromptChange: (value: string) => void;
   onGenerateOutline: () => void;
   // Chapter generation
@@ -55,9 +57,11 @@ export function GenerateView({
   generationState,
   outlineChapters,
   outlineWordCount,
+  outlineMinChapterWords,
   outlineCustomPrompt,
   onOutlineChaptersChange,
   onOutlineWordCountChange,
+  onOutlineMinChapterWordsChange,
   onOutlineCustomPromptChange,
   onGenerateOutline,
   generateCount,
@@ -124,7 +128,7 @@ export function GenerateView({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-3 lg:gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 lg:gap-4">
             <div className="space-y-2">
               <Label className="text-xs lg:text-sm">目标章数</Label>
               <Input
@@ -140,6 +144,18 @@ export function GenerateView({
                 type="number"
                 value={outlineWordCount}
                 onChange={(e) => onOutlineWordCountChange(e.target.value)}
+                className="bg-muted/50 text-sm"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs lg:text-sm">每章最少字数</Label>
+              <Input
+                type="number"
+                min={500}
+                max={20000}
+                step={100}
+                value={outlineMinChapterWords}
+                onChange={(e) => onOutlineMinChapterWordsChange(e.target.value)}
                 className="bg-muted/50 text-sm"
               />
             </div>
@@ -172,6 +188,7 @@ export function GenerateView({
                 <p>
                   {project.outline.volumes.length} 卷 / {project.outline.totalChapters} 章 / {project.outline.targetWordCount} 万字
                 </p>
+                <p>当前每章最少字数: {project.state.minChapterWords} 字</p>
               </div>
             </div>
           )}

--- a/web/src/pages/project/DashboardPage.tsx
+++ b/web/src/pages/project/DashboardPage.tsx
@@ -24,11 +24,17 @@ export default function DashboardPage() {
 
   const defaultOutlineChapters = Math.max(1, selectedProject.state.totalChapters || 400);
   const defaultOutlineWordCount = Math.max(5, Math.round(defaultOutlineChapters / 4));
+  const defaultMinChapterWords = Math.max(500, selectedProject.state.minChapterWords || 2500);
 
   return (
     <DashboardView 
       project={selectedProject} 
-      onGenerateOutline={() => handleGenerateOutline(String(defaultOutlineChapters), String(defaultOutlineWordCount), '')}
+      onGenerateOutline={() => handleGenerateOutline(
+        String(defaultOutlineChapters),
+        String(defaultOutlineWordCount),
+        String(defaultMinChapterWords),
+        ''
+      )}
       onGenerateChapters={() => handleGenerateChapters('1')}
       loading={loading}
     />

--- a/web/src/pages/project/GeneratePage.tsx
+++ b/web/src/pages/project/GeneratePage.tsx
@@ -19,6 +19,7 @@ export default function GeneratePage() {
   // Local form state for this page
   const [outlineChapters, setOutlineChapters] = useState('400');
   const [outlineWordCount, setOutlineWordCount] = useState('100');
+  const [outlineMinChapterWords, setOutlineMinChapterWords] = useState('2500');
   const [outlineCustomPrompt, setOutlineCustomPrompt] = useState('');
   const [generateCount, setGenerateCount] = useState('1');
 
@@ -28,10 +29,17 @@ export default function GeneratePage() {
     const targetWordCount = selectedProject.outline?.targetWordCount
       ? Math.max(1, selectedProject.outline.targetWordCount)
       : Math.max(5, Math.round(targetChapters / 4));
+    const minChapterWords = Math.max(500, selectedProject.state.minChapterWords || 2500);
     setOutlineChapters(String(targetChapters));
     setOutlineWordCount(String(targetWordCount));
+    setOutlineMinChapterWords(String(minChapterWords));
     setGenerateCount('1');
-  }, [selectedProject?.name]);
+  }, [
+    selectedProject?.id,
+    selectedProject?.state.totalChapters,
+    selectedProject?.state.minChapterWords,
+    selectedProject?.outline?.targetWordCount,
+  ]);
 
   if (!selectedProject) {
     return <NoProjectSelected title="未找到项目" description="请先选择有效项目后再进行生成。"/>;
@@ -45,14 +53,16 @@ export default function GeneratePage() {
       generationState={generationState}
       outlineChapters={outlineChapters}
       outlineWordCount={outlineWordCount}
+      outlineMinChapterWords={outlineMinChapterWords}
       outlineCustomPrompt={outlineCustomPrompt}
       onOutlineChaptersChange={setOutlineChapters}
       onOutlineWordCountChange={setOutlineWordCount}
+      onOutlineMinChapterWordsChange={setOutlineMinChapterWords}
       onOutlineCustomPromptChange={setOutlineCustomPrompt}
-      onGenerateOutline={() => handleGenerateOutline(outlineChapters, outlineWordCount, outlineCustomPrompt)}
+      onGenerateOutline={() => handleGenerateOutline(outlineChapters, outlineWordCount, outlineMinChapterWords, outlineCustomPrompt)}
       generateCount={generateCount}
       onGenerateCountChange={setGenerateCount}
-      onGenerateChapters={() => handleGenerateChapters(generateCount)}
+      onGenerateChapters={() => handleGenerateChapters(generateCount, undefined, undefined, outlineMinChapterWords)}
       onCancelGeneration={handleCancelGeneration}
       cancelingGeneration={cancelingGeneration}
       onResetState={handleResetProject}


### PR DESCRIPTION
## 变更内容\n- 新增 states.min_chapter_words 字段与迁移 0018\n- 生成页增加“每章最少字数”配置并透传到后端\n- 章节生成 prompt/QC 按最少字数执行，不达标触发重写\n- outline/generate/generate-stream 支持并持久化 minChapterWords\n\n## 验证\n- pnpm typecheck\n- pnpm build:web\n- pnpm db:migrate:local