### PR TITLE
fix: iOS 键盘避让 + 最小章节字数同步

### DIFF
--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -110,7 +110,7 @@ export async function fetchProject(
 export async function createProject(
   apiBaseUrl: string,
   token: string,
-  payload: { name: string; bible: string; totalChapters: number },
+  payload: { name: string; bible: string; totalChapters: number; minChapterWords?: number },
 ): Promise<void> {
   const res = await fetch(buildApiUrl(apiBaseUrl, '/projects'), {
     method: 'POST',
@@ -270,6 +270,7 @@ export async function generateOutlineStream(
   payload: {
     targetChapters: number;
     targetWordCount: number;
+    minChapterWords?: number;
     customPrompt?: string;
   },
   onEvent: (event: OutlineStreamEvent) => void,
@@ -311,7 +312,7 @@ export async function generateChaptersStream(
   apiBaseUrl: string,
   token: string,
   projectRef: string,
-  payload: { chaptersToGenerate: number },
+  payload: { chaptersToGenerate: number; minChapterWords?: number },
   onEvent: (event: GenerationStreamEvent) => void,
   aiConfig?: AppConfig['ai'],
 ): Promise<{ generated: { chapter: number; title: string }[]; failedChapters: number[] }> {

--- a/mobile/src/screens/admin/AdminScreen.tsx
+++ b/mobile/src/screens/admin/AdminScreen.tsx
@@ -6,6 +6,7 @@ import {
   ScrollView,
   TouchableOpacity,
   StyleSheet,
+  KeyboardAvoidingView,
   Modal,
   TextInput,
   Alert,
@@ -13,7 +14,7 @@ import {
   Switch,
   Platform,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { ui } from '../../theme/tokens';
@@ -26,6 +27,7 @@ type Tab = 'models' | 'credit';
 
 export function AdminScreen() {
   const navigation = useNavigation();
+  const insets = useSafeAreaInsets();
   const { token } = useAuth();
   const { config } = useAppConfig();
   const [activeTab, setActiveTab] = useState<Tab>('models');
@@ -274,7 +276,11 @@ export function AdminScreen() {
       transparent={true}
       onRequestClose={() => setModelModalVisible(false)}
     >
-      <View style={styles.modalOverlay}>
+      <KeyboardAvoidingView
+        style={styles.modalOverlay}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={insets.top + 8}
+      >
         <View style={styles.modalContent}>
           <View style={styles.modalHeader}>
             <Text style={styles.modalTitle}>{editingModel?.id ? '编辑模型' : '添加模型'}</Text>
@@ -282,7 +288,7 @@ export function AdminScreen() {
               <Ionicons name="close" size={24} color={ui.colors.text} />
             </TouchableOpacity>
           </View>
-          <ScrollView>
+          <ScrollView keyboardShouldPersistTaps="handled" keyboardDismissMode="on-drag">
             <Text style={styles.label}>显示名称</Text>
             <TextInput
               style={styles.input}
@@ -336,7 +342,7 @@ export function AdminScreen() {
             <Text style={styles.saveButtonText}>保存</Text>
           </TouchableOpacity>
         </View>
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 
@@ -347,7 +353,11 @@ export function AdminScreen() {
       transparent={true}
       onRequestClose={() => setCreditModalVisible(false)}
     >
-      <View style={styles.modalOverlay}>
+      <KeyboardAvoidingView
+        style={styles.modalOverlay}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={insets.top + 8}
+      >
          <View style={[styles.modalContent, { height: 'auto', maxHeight: 300 }]}>
             <Text style={styles.modalTitle}>修改定价: {editingFeature?.name}</Text>
             <Text style={styles.label}>基础消耗</Text>
@@ -373,7 +383,7 @@ export function AdminScreen() {
                </TouchableOpacity>
             </View>
          </View>
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 

--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  KeyboardAvoidingView,
   Linking,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -63,120 +65,130 @@ export function SettingsScreen() {
   return (
     <SafeAreaView style={styles.safeArea} edges={['top', 'bottom']}>
       <LinearGradient colors={gradients.page} style={styles.bgGradient}>
-        <ScrollView contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + 112 }]}>
-          <View style={styles.headerWrap}>
-            <Text style={styles.pageTitle}>设置</Text>
-            <Text style={styles.pageSubtitle}>管理账号与服务连接</Text>
-          </View>
-
-          <View style={styles.statusStrip}>
-            <View style={styles.statusChip}>
-              <Ionicons name="flash" size={14} color={ui.colors.accent} />
-              <Text style={styles.statusChipText}>
-                剩余积分：{user?.credit_balance !== undefined ? user.credit_balance : '...'}
-              </Text>
+        <KeyboardAvoidingView
+          style={styles.flex}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          keyboardVerticalOffset={insets.top + 8}
+        >
+          <ScrollView
+            contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + 112 }]}
+            keyboardShouldPersistTaps="handled"
+            keyboardDismissMode="on-drag"
+          >
+            <View style={styles.headerWrap}>
+              <Text style={styles.pageTitle}>设置</Text>
+              <Text style={styles.pageSubtitle}>管理账号与服务连接</Text>
             </View>
-            <Text style={styles.statusHost} numberOfLines={1}>{apiBaseUrl.replace(/^https?:\/\//, '')}</Text>
-          </View>
 
-          <View style={[styles.card, styles.accountCard]}>
-            <View style={styles.sectionTitleRow}>
-              <Ionicons name="person-circle-outline" size={18} color={ui.colors.primaryStrong} />
-              <Text style={styles.cardTitle}>账号</Text>
+            <View style={styles.statusStrip}>
+              <View style={styles.statusChip}>
+                <Ionicons name="flash" size={14} color={ui.colors.accent} />
+                <Text style={styles.statusChipText}>
+                  剩余积分：{user?.credit_balance !== undefined ? user.credit_balance : '...'}
+                </Text>
+              </View>
+              <Text style={styles.statusHost} numberOfLines={1}>{apiBaseUrl.replace(/^https?:\/\//, '')}</Text>
             </View>
-            <Text style={styles.accountText}>当前用户：{user?.username || '未知'}</Text>
-            <Text style={styles.accountRole}>用户ID：{user?.id || '...'}</Text>
-            <Text style={styles.accountRole}>权限组：{user?.role || 'user'}</Text>
-            
-            {user?.role === 'admin' && (
-              <Pressable style={({ pressed }) => [styles.adminButton, pressed && styles.pressed]} onPress={openAdminPanel}>
-                <Ionicons name="settings-outline" size={16} color={ui.colors.primaryStrong} />
-                <Text style={styles.adminButtonText}>打开管理后台</Text>
+
+            <View style={[styles.card, styles.accountCard]}>
+              <View style={styles.sectionTitleRow}>
+                <Ionicons name="person-circle-outline" size={18} color={ui.colors.primaryStrong} />
+                <Text style={styles.cardTitle}>账号</Text>
+              </View>
+              <Text style={styles.accountText}>当前用户：{user?.username || '未知'}</Text>
+              <Text style={styles.accountRole}>用户ID：{user?.id || '...'}</Text>
+              <Text style={styles.accountRole}>权限组：{user?.role || 'user'}</Text>
+              
+              {user?.role === 'admin' && (
+                <Pressable style={({ pressed }) => [styles.adminButton, pressed && styles.pressed]} onPress={openAdminPanel}>
+                  <Ionicons name="settings-outline" size={16} color={ui.colors.primaryStrong} />
+                  <Text style={styles.adminButtonText}>打开管理后台</Text>
+                </Pressable>
+              )}
+
+              <Pressable style={({ pressed }) => [styles.logoutButton, pressed && styles.pressed]} onPress={handleLogout}>
+                <Ionicons name="log-out-outline" size={16} color="#fff" />
+                <Text style={styles.logoutButtonText}>退出登录</Text>
               </Pressable>
-            )}
-
-            <Pressable style={({ pressed }) => [styles.logoutButton, pressed && styles.pressed]} onPress={handleLogout}>
-              <Ionicons name="log-out-outline" size={16} color="#fff" />
-              <Text style={styles.logoutButtonText}>退出登录</Text>
-            </Pressable>
-          </View>
-
-          <View style={[styles.card, styles.serviceCard]}>
-            <View style={styles.sectionTitleRow}>
-              <Ionicons name="cloud-outline" size={18} color={ui.colors.primaryStrong} />
-              <Text style={styles.cardTitle}>服务地址</Text>
             </View>
-            <Text style={styles.label}>后端地址</Text>
-            <TextInput
-              value={apiBaseUrl}
-              onChangeText={setApiBaseUrl}
-              autoCapitalize="none"
-              style={styles.input}
-              placeholder="https://novel-copilot.doctoroyy.workers.dev"
-              placeholderTextColor={ui.colors.textTertiary}
-            />
-            <Text style={styles.hintText}>
-              无需配置 API Key，AI 模型由服务端统一管理。
-            </Text>
-          </View>
 
-          {user?.allow_custom_provider && (
             <View style={[styles.card, styles.serviceCard]}>
               <View style={styles.sectionTitleRow}>
-                <Ionicons name="options-outline" size={18} color={ui.colors.primaryStrong} />
-                <Text style={styles.cardTitle}>自定义模型配置</Text>
+                <Ionicons name="cloud-outline" size={18} color={ui.colors.primaryStrong} />
+                <Text style={styles.cardTitle}>服务地址</Text>
               </View>
+              <Text style={styles.label}>后端地址</Text>
+              <TextInput
+                value={apiBaseUrl}
+                onChangeText={setApiBaseUrl}
+                autoCapitalize="none"
+                style={styles.input}
+                placeholder="https://novel-copilot.doctoroyy.workers.dev"
+                placeholderTextColor={ui.colors.textTertiary}
+              />
               <Text style={styles.hintText}>
-                您拥有自定义模型权限，设置后将覆盖默认模型。
+                无需配置 API Key，AI 模型由服务端统一管理。
               </Text>
-              
-              <Text style={styles.label}>提供商 (Provider)</Text>
-              <TextInput
-                value={config.ai?.provider || ''}
-                onChangeText={(v) => updateConfig({ ...config, ai: { ...config.ai, provider: v } as any })}
-                autoCapitalize="none"
-                style={styles.input}
-                placeholder="openai, anthropic, etc."
-                placeholderTextColor={ui.colors.textTertiary}
-              />
-
-              <Text style={styles.label}>模型名称 (Model)</Text>
-              <TextInput
-                value={config.ai?.model || ''}
-                onChangeText={(v) => updateConfig({ ...config, ai: { ...config.ai, model: v } as any })}
-                autoCapitalize="none"
-                style={styles.input}
-                placeholder="gpt-4o, claude-3-5-sonnet..."
-                placeholderTextColor={ui.colors.textTertiary}
-              />
-
-              <Text style={styles.label}>API Base URL</Text>
-              <TextInput
-                value={config.ai?.baseUrl || ''}
-                onChangeText={(v) => updateConfig({ ...config, ai: { ...config.ai, baseUrl: v } as any })}
-                autoCapitalize="none"
-                style={styles.input}
-                placeholder="https://api.openai.com/v1"
-                placeholderTextColor={ui.colors.textTertiary}
-              />
-
-              <Text style={styles.label}>API Key</Text>
-              <TextInput
-                value={config.ai?.apiKey || ''}
-                onChangeText={(v) => updateConfig({ ...config, ai: { ...config.ai, apiKey: v } as any })}
-                autoCapitalize="none"
-                secureTextEntry
-                style={styles.input}
-                placeholder="sk-..."
-                placeholderTextColor={ui.colors.textTertiary}
-              />
             </View>
-          )}
 
-          <Pressable style={({ pressed }) => [styles.saveButton, pressed && styles.pressed]} onPress={() => void handleSave()} disabled={saving}>
-            {saving ? <ActivityIndicator color="#fff" /> : <Text style={styles.saveButtonText}>保存设置</Text>}
-          </Pressable>
-        </ScrollView>
+            {user?.allow_custom_provider && (
+              <View style={[styles.card, styles.serviceCard]}>
+                <View style={styles.sectionTitleRow}>
+                  <Ionicons name="options-outline" size={18} color={ui.colors.primaryStrong} />
+                  <Text style={styles.cardTitle}>自定义模型配置</Text>
+                </View>
+                <Text style={styles.hintText}>
+                  您拥有自定义模型权限，设置后将覆盖默认模型。
+                </Text>
+                
+                <Text style={styles.label}>提供商 (Provider)</Text>
+                <TextInput
+                  value={config.ai?.provider || ''}
+                  onChangeText={(v) => updateConfig({ ...config, ai: { ...config.ai, provider: v } as any })}
+                  autoCapitalize="none"
+                  style={styles.input}
+                  placeholder="openai, anthropic, etc."
+                  placeholderTextColor={ui.colors.textTertiary}
+                />
+
+                <Text style={styles.label}>模型名称 (Model)</Text>
+                <TextInput
+                  value={config.ai?.model || ''}
+                  onChangeText={(v) => updateConfig({ ...config, ai: { ...config.ai, model: v } as any })}
+                  autoCapitalize="none"
+                  style={styles.input}
+                  placeholder="gpt-4o, claude-3-5-sonnet..."
+                  placeholderTextColor={ui.colors.textTertiary}
+                />
+
+                <Text style={styles.label}>API Base URL</Text>
+                <TextInput
+                  value={config.ai?.baseUrl || ''}
+                  onChangeText={(v) => updateConfig({ ...config, ai: { ...config.ai, baseUrl: v } as any })}
+                  autoCapitalize="none"
+                  style={styles.input}
+                  placeholder="https://api.openai.com/v1"
+                  placeholderTextColor={ui.colors.textTertiary}
+                />
+
+                <Text style={styles.label}>API Key</Text>
+                <TextInput
+                  value={config.ai?.apiKey || ''}
+                  onChangeText={(v) => updateConfig({ ...config, ai: { ...config.ai, apiKey: v } as any })}
+                  autoCapitalize="none"
+                  secureTextEntry
+                  style={styles.input}
+                  placeholder="sk-..."
+                  placeholderTextColor={ui.colors.textTertiary}
+                />
+              </View>
+            )}
+
+            <Pressable style={({ pressed }) => [styles.saveButton, pressed && styles.pressed]} onPress={() => void handleSave()} disabled={saving}>
+              {saving ? <ActivityIndicator color="#fff" /> : <Text style={styles.saveButtonText}>保存设置</Text>}
+            </Pressable>
+          </ScrollView>
+        </KeyboardAvoidingView>
       </LinearGradient>
     </SafeAreaView>
   );
@@ -188,6 +200,9 @@ const styles = StyleSheet.create({
     backgroundColor: ui.colors.bg,
   },
   bgGradient: {
+    flex: 1,
+  },
+  flex: {
     flex: 1,
   },
   content: {

--- a/mobile/src/types/domain.ts
+++ b/mobile/src/types/domain.ts
@@ -11,6 +11,7 @@ export type User = {
 export type BookState = {
   bookTitle: string;
   totalChapters: number;
+  minChapterWords?: number;
   nextChapterIndex: number;
   rollingSummary: string;
   openLoops: string[];

--- a/web/src/layouts/ProjectLayout.tsx
+++ b/web/src/layouts/ProjectLayout.tsx
@@ -55,6 +55,7 @@ function ProjectLayoutInner() {
   const [newProjectName, setNewProjectName] = useState('');
   const [newProjectBible, setNewProjectBible] = useState('');
   const [newProjectChapters, setNewProjectChapters] = useState('400');
+  const [newProjectMinChapterWords, setNewProjectMinChapterWords] = useState('2500');
   const [aiGenre, setAiGenre] = useState('');
   const [aiTheme, setAiTheme] = useState('');
   const [aiKeywords, setAiKeywords] = useState('');
@@ -80,6 +81,7 @@ function ProjectLayoutInner() {
     const trimmedName = newProjectName.trim();
     const trimmedBible = newProjectBible.trim();
     const parsedChapters = Number.parseInt(newProjectChapters, 10);
+    const parsedMinChapterWords = Number.parseInt(newProjectMinChapterWords, 10);
 
     if (!trimmedName) {
       setError('请输入项目名称');
@@ -93,12 +95,17 @@ function ProjectLayoutInner() {
       setError('目标章节数必须是大于 0 的整数');
       return;
     }
+    if (!Number.isInteger(parsedMinChapterWords) || parsedMinChapterWords < 500 || parsedMinChapterWords > 20000) {
+      setError('每章最少字数必须是 500~20000 的整数');
+      return;
+    }
 
     try {
-      await handleCreateProject(trimmedName, trimmedBible, String(parsedChapters));
+      await handleCreateProject(trimmedName, trimmedBible, String(parsedChapters), String(parsedMinChapterWords));
       setNewProjectName('');
       setNewProjectBible('');
       setNewProjectChapters('400');
+      setNewProjectMinChapterWords('2500');
       setAiGenre('');
       setAiTheme('');
       setAiKeywords('');
@@ -243,6 +250,20 @@ function ProjectLayoutInner() {
             </div>
 
             <div className="space-y-2">
+              <Label htmlFor="minChapterWords">每章最少字数</Label>
+              <Input
+                id="minChapterWords"
+                type="number"
+                min={500}
+                max={20000}
+                step={100}
+                value={newProjectMinChapterWords}
+                onChange={(e) => setNewProjectMinChapterWords(e.target.value)}
+                placeholder="2500"
+              />
+            </div>
+
+            <div className="space-y-2">
               <Label>AI 辅助生成设定 (可选)</Label>
               <div className="grid grid-cols-2 gap-2">
                 <Input
@@ -296,6 +317,9 @@ function ProjectLayoutInner() {
                 !newProjectBible.trim() ||
                 !Number.isInteger(Number.parseInt(newProjectChapters, 10)) ||
                 Number.parseInt(newProjectChapters, 10) <= 0 ||
+                !Number.isInteger(Number.parseInt(newProjectMinChapterWords, 10)) ||
+                Number.parseInt(newProjectMinChapterWords, 10) < 500 ||
+                Number.parseInt(newProjectMinChapterWords, 10) > 20000 ||
                 loading
               }
             >


### PR DESCRIPTION
## 变更内容
- 修复 iOS 多处输入页面键盘遮挡输入区（ProjectsHome / ProjectDetail / Settings / AnimeStudio / Admin Modal）
- 移动端创建项目新增并校验“每章最少字数”，并提交到后端
- 移动端大纲生成参数新增“每章最少字数”，默认回填项目配置
- 移动端章节生成请求带上项目 `minChapterWords`
- Web 新建项目弹窗新增“每章最少字数”输入并透传

## 验证
- `pnpm mobile:typecheck`
- `pnpm build:web`
- `pnpm typecheck`
