### PR TITLE
feat: support batch model operations grouped by provider

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1285,6 +1285,29 @@ export async function updateModel(id: string, updates: any): Promise<void> {
   if (!data.success) throw new Error(data.error);
 }
 
+
+export async function batchUpdateModels(ids: string[], updates: any): Promise<number> {
+  const res = await fetch(`${API_BASE}/admin/model-registry/batch`, {
+    method: 'PUT',
+    headers: mergeHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ ids, updates }),
+  });
+  const data = await res.json();
+  if (!data.success) throw new Error(data.error);
+  return data.count;
+}
+
+export async function batchDeleteModels(ids: string[]): Promise<number> {
+  const res = await fetch(`${API_BASE}/admin/model-registry/batch`, {
+    method: 'DELETE',
+    headers: mergeHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ ids }),
+  });
+  const data = await res.json();
+  if (!data.success) throw new Error(data.error);
+  return data.count;
+}
+
 export async function deleteModel(id: string): Promise<void> {
   const res = await fetch(`${API_BASE}/admin/model-registry/${id}`, {
     method: 'DELETE',


### PR DESCRIPTION
This pull request adds support for batch operations on registered AI models in the admin panel.
It groups the registered models by provider, and allows the administrator to select multiple models across providers to perform batch operations such as enable/disable, modify base URL, API key, and credit multiplier, or delete them entirely. The database queries process updates in chunks of 20 to avoid exceeding parameter limits.

---
*PR created automatically by Jules for task [7346417463673982639](https://jules.google.com/task/7346417463673982639) started by @doctoroyy*