### PR TITLE
feat(admin): allow naming custom AI providers

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -513,7 +513,7 @@ adminRoutes.get('/model-registry', async (c) => {
 // Create model
 adminRoutes.post('/model-registry', async (c) => {
   try {
-    const { providerId, modelName, displayName, creditMultiplier, capabilities, configJson } = await c.req.json();
+    const { providerId, customProviderName, modelName, displayName, creditMultiplier, capabilities, configJson } = await c.req.json();
     if (!providerId || !modelName) {
       return c.json({ success: false, error: 'providerId, modelName 不能为空' }, 400);
     }
@@ -528,6 +528,11 @@ adminRoutes.post('/model-registry', async (c) => {
           INSERT INTO provider_registry (id, name, protocol, base_url)
           VALUES (?, ?, ?, ?)
         `).bind(preset.id, preset.label, preset.protocol, preset.defaultBaseUrl || null).run();
+      } else if (providerId.startsWith('custom')) {
+        await c.env.DB.prepare(`
+          INSERT INTO provider_registry (id, name, protocol, base_url)
+          VALUES (?, ?, ?, ?)
+        `).bind(providerId, customProviderName || providerId, 'openai', null).run();
       } else {
         return c.json({ success: false, error: 'Provider 不存在且非预设' }, 400);
       }

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -1235,6 +1235,16 @@ export function AdminPage() {
                           </SelectContent>
                         </Select>
                       </div>
+                      {newModelForm.providerId === 'custom' && (
+                        <div>
+                          <label className="text-xs text-muted-foreground">自定义提供商名称</label>
+                          <Input
+                            placeholder="如: 我的自定义大模型"
+                            value={newModelForm.customProviderName || ''}
+                            onChange={(e) => setNewModelForm({ ...newModelForm, customProviderName: e.target.value })}
+                          />
+                        </div>
+                      )}
                       <div>
                         <label className="text-xs text-muted-foreground">模型名称</label>
                         <Input value={newModelForm.modelName} onChange={(e) => setNewModelForm({ ...newModelForm, modelName: e.target.value })} />
@@ -1257,11 +1267,15 @@ export function AdminPage() {
                             return;
                           }
 
-                          await createModel({
-                            ...newModelForm,
-                            modelName: normalizedModelName,
-                            displayName: String(newModelForm.displayName || normalizedModelName).trim(),
-                          });
+                          const payload = { ...newModelForm, modelName: normalizedModelName, displayName: String(newModelForm.displayName || normalizedModelName).trim() };
+                          if (payload.providerId === 'custom') {
+                            payload.providerId = `custom-${Date.now()}`;
+                            if (!payload.customProviderName || payload.customProviderName.trim() === '') {
+                              payload.customProviderName = `custom${Math.floor(Math.random() * 10000)}`;
+                            }
+                          }
+
+                          await createModel(payload);
                           setNewModelForm(null);
                           fetchData();
                         } catch (e) { setError((e as Error).message); }


### PR DESCRIPTION
This PR allows administrators to assign custom names when registering new custom AI providers. Previously, all custom providers were given the same `providerId` ('custom'), leading to them overwriting each other in the `provider_registry`. 

This has been resolved by:
1. Generating a unique `providerId` (via timestamp) for each custom provider submitted.
2. Allowing the user to input a `customProviderName` in the Admin UI which is sent to the backend.
3. If no name is provided, automatically generating a name like `custom1234` as requested.
4. Saving this newly named provider to the database on the backend when adding the model.

---
*PR created automatically by Jules for task [10149407179593863935](https://jules.google.com/task/10149407179593863935) started by @doctoroyy*